### PR TITLE
[3] chore: add useCombinedQueries

### DIFF
--- a/src/combination.ts
+++ b/src/combination.ts
@@ -1,0 +1,97 @@
+import {
+  DefinedQueryObserverResult,
+  QueryObserverResult,
+} from '@tanstack/react-query';
+
+type CombinedQueriesBaseResult = {
+  isFetching: boolean;
+  isRefetching: boolean;
+  refetchAll: () => void;
+};
+
+type DataOfQuery<Query> = Query extends QueryObserverResult<infer Data>
+  ? Data
+  : never;
+
+// Data is defined -- not loading and not error.
+export type CombinedQueriesDefinedResult<
+  Queries extends QueryObserverResult[],
+> = {
+  isLoading: false;
+  isError: false;
+  data: {
+    [Index in keyof Queries]: DataOfQuery<Queries[Index]>;
+  };
+  queries: {
+    [Index in keyof Queries]: DefinedQueryObserverResult<
+      DataOfQuery<Queries[Index]>
+    >;
+  };
+};
+
+export type CombinedQueriesLoadingResult<
+  Queries extends QueryObserverResult[],
+> = {
+  isLoading: true;
+  isError: false;
+  data: undefined;
+  queries: Queries;
+};
+
+export type CombinedQueriesErrorResult<Queries extends QueryObserverResult[]> =
+  {
+    isLoading: false;
+    isError: true;
+    data: undefined;
+    queries: Queries;
+  };
+
+export type CombinedQueriesResult<Queries extends QueryObserverResult[]> =
+  CombinedQueriesBaseResult &
+    (
+      | CombinedQueriesDefinedResult<Queries>
+      | CombinedQueriesLoadingResult<Queries>
+      | CombinedQueriesErrorResult<Queries>
+    );
+
+export const combineQueries = <Queries extends QueryObserverResult[]>(
+  queries: [...Queries],
+): CombinedQueriesResult<Queries> => {
+  const base = {
+    isFetching: queries.some((query) => query.isFetching),
+    isRefetching: queries.some((query) => query.isRefetching),
+    refetchAll: () => {
+      queries.forEach((query) => {
+        void query.refetch();
+      });
+    },
+  };
+
+  if (queries.some((query) => query.status === 'error')) {
+    return {
+      ...base,
+      isLoading: false,
+      data: undefined,
+      isError: true,
+      queries,
+    };
+  }
+
+  if (queries.some((query) => query.status === 'loading')) {
+    return {
+      ...base,
+      isLoading: true,
+      data: undefined,
+      isError: false,
+      queries,
+    };
+  }
+
+  return {
+    ...base,
+    isLoading: false,
+    data: queries.map((query) => query.data) as any,
+    isError: false,
+    queries: queries as any,
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export * from './types';
 export * from './util';
+export * from './hooks';
+export * from './combination';
+export * from './test-utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
 import {
+  QueryObserverResult,
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
+import { CombinedQueriesResult } from './combination';
 
 /**
  * Extracts the path parameters from a route.
@@ -48,6 +50,19 @@ type RestrictedUseQueryOptions<Response> = Omit<
   'queryKey' | 'queryFn'
 >;
 
+export type CombinedRouteTuples<
+  Endpoints extends RoughEndpoints,
+  Routes extends (keyof Endpoints)[],
+> = {
+  [Index in keyof Routes]:
+    | [Routes[Index], RequestPayloadOf<Endpoints, Routes[Index]>]
+    | [
+        Routes[Index],
+        RequestPayloadOf<Endpoints, Routes[Index]>,
+        UseQueryOptions<Endpoints[Routes[Index]]['Response']> | undefined,
+      ];
+};
+
 export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
   useQuery: <Route extends keyof Endpoints & string>(
     route: Route,
@@ -67,4 +82,12 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
     unknown,
     RequestPayloadOf<Endpoints, Route>
   >;
+
+  useCombinedQueries<Routes extends (keyof Endpoints & string)[]>(
+    ...routes: [...CombinedRouteTuples<Endpoints, Routes>]
+  ): CombinedQueriesResult<{
+    [Index in keyof Routes]: QueryObserverResult<
+      Endpoints[Routes[Index]]['Response']
+    >;
+  }>;
 };


### PR DESCRIPTION
## Motivation
Adding the `useCombinedQuery` hook to the utility. This was copypasta.

**Interesting**:
- I extracted out the core "combination" logic from `useCombinedQuery` into a simple function: `combineQueries`. This will have the nice effect of allowing consumers to combine queries from _different_ APIs into a single combined value (something we can't currently do in `ClientUI`.
<!-- Describe _why_ this change should merge. -->