### PR TITLE
[4] chore: add useCache hook with invalidation utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^4.12.0",
     "@testing-library/react": "^13.4.0",
     "@types/jest": "^29.2.0",
+    "@types/lodash": "^4.14.186",
     "@types/react": "^18.0.21",
     "@types/uuid": "^8.3.4",
     "axios": "^0.27.2",
@@ -41,5 +42,8 @@
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4",
     "uuid": "^9.0.0"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,50 @@
+import { QueryClient, QueryFilters } from '@tanstack/react-query';
+// eslint-disable-next-line no-restricted-imports
+import { isEqual } from 'lodash';
+import { CacheUtils, EndpointInvalidationMap, RoughEndpoints } from './types';
+import { isInternalQueryKey } from './util';
+
+const createQueryFilterFromSpec = <Endpoints extends RoughEndpoints>(
+  endpoints: EndpointInvalidationMap<Endpoints>,
+): QueryFilters => ({
+  predicate: (query) =>
+    query.queryKey.some((entry) => {
+      if (!isInternalQueryKey(entry)) {
+        return false;
+      }
+
+      const payloadsToInvalidate = endpoints[entry.route];
+      if (!payloadsToInvalidate) {
+        return false;
+      }
+
+      // Handle 'all'
+      if (payloadsToInvalidate === 'all') {
+        return true;
+      }
+
+      // Handle predicate function
+      if (typeof payloadsToInvalidate === 'function') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return payloadsToInvalidate(entry.payload as any);
+      }
+
+      // Handle list of variables
+      return payloadsToInvalidate.some((payload) =>
+        isEqual(payload, entry.payload),
+      );
+    }),
+});
+
+export const createCacheUtils = <Endpoints extends RoughEndpoints>(
+  client: QueryClient,
+): CacheUtils<Endpoints> => {
+  return {
+    invalidateQueries: (spec) => {
+      void client.invalidateQueries(createQueryFilterFromSpec(spec));
+    },
+    resetQueries: (spec) => {
+      void client.resetQueries(createQueryFilterFromSpec(spec));
+    },
+  };
+};

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,7 +3,9 @@ import {
   useMutation,
   QueryKey,
   useQueries,
+  useQueryClient,
 } from '@tanstack/react-query';
+import { createCacheUtils } from './cache';
 import { combineQueries } from './combination';
 import { APIQueryHooks, RoughEndpoints } from './types';
 import { APIClient, createQueryKey } from './util';
@@ -35,7 +37,7 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
       const queries = useQueries({
         queries: routes.map(([endpoint, payload, options]) => ({
           ...options,
-          queryKey: [createQueryKey('preventia', endpoint, payload)],
+          queryKey: [createQueryKey(name, endpoint, payload)],
           queryFn: () =>
             client.request(endpoint, payload).then((res) => res.data),
         })),
@@ -46,6 +48,10 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
       // simple solution.
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return combineQueries(queries as any);
+    },
+    useCache: () => {
+      const client = useQueryClient();
+      return createCacheUtils(client);
     },
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,23 @@ export type CombinedRouteTuples<
       ];
 };
 
+export type EndpointInvalidationPredicate<Payload> =
+  | 'all'
+  | Payload[]
+  | ((payload: Payload) => boolean);
+
+export type EndpointInvalidationMap<Endpoints extends RoughEndpoints> = {
+  [Route in keyof Endpoints]?: EndpointInvalidationPredicate<
+    RequestPayloadOf<Endpoints, Route>
+  >;
+};
+
+export type CacheUtils<Endpoints extends RoughEndpoints> = {
+  invalidateQueries: (spec: EndpointInvalidationMap<Endpoints>) => void;
+
+  resetQueries: (spec: EndpointInvalidationMap<Endpoints>) => void;
+};
+
 export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
   useQuery: <Route extends keyof Endpoints & string>(
     route: Route,
@@ -90,4 +107,6 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
       Endpoints[Routes[Index]]['Response']
     >;
   }>;
+
+  useCache(): CacheUtils<Endpoints>;
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -95,3 +95,9 @@ export const createQueryKey = (
   route: string,
   payload: unknown,
 ): InternalQueryKey => ({ name, route, payload });
+
+export const isInternalQueryKey = (key: any): key is InternalQueryKey =>
+  typeof key === 'object' &&
+  'name' in key &&
+  'route' in key &&
+  'payload' in key;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,6 +1184,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/lodash@^4.14.186":
+  version "4.14.186"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
+  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"


### PR DESCRIPTION
## Motivation
Adding the caching util. The name of this API has changed slightly from `useInvalidation` to `useCache`.

Again, this is copy-pasta, with variables changed to reference the `TestEndpoints` instead of the Preventia-specific logic.
<!-- Describe _why_ this change should merge. -->