### PR TITLE
chore: update code to match docs for hooks creation

### DIFF
--- a/src/hooks.test.tsx
+++ b/src/hooks.test.tsx
@@ -4,7 +4,6 @@ import { useQuery as useReactQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { createAPIHooks } from './hooks';
 import { createAPIMockingUtility } from './test-utils';
-import { APIClient } from './util';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CacheUtils, EndpointInvalidationMap, RequestPayloadOf } from './types';
 
@@ -27,16 +26,15 @@ type TestEndpoints = {
   };
 };
 
-const client = new APIClient<TestEndpoints>(
-  axios.create({ baseURL: 'https://www.lifeomic.com' }),
-);
+const client = axios.create({ baseURL: 'https://www.lifeomic.com' });
 
 jest.spyOn(client, 'request');
 
-const { useQuery, useMutation, useCombinedQueries, useCache } = createAPIHooks({
-  name: 'test-name',
-  client,
-});
+const { useQuery, useMutation, useCombinedQueries, useCache } =
+  createAPIHooks<TestEndpoints>({
+    name: 'test-name',
+    client,
+  });
 
 const network = createAPIMockingUtility<TestEndpoints>({
   baseUrl: 'https://www.lifeomic.com',
@@ -456,9 +454,10 @@ describe('useCache', () => {
             invalidate: {},
             getRenderData: () => {
               const { data } = useReactQuery(['some-other-key'], () =>
-                client.request('GET /items/:id', {
-                  id: 'some-id',
-                  filter: 'some-filter',
+                client.request({
+                  method: 'GET',
+                  url: '/items/some-id',
+                  params: { filter: 'some-filter' },
                 }),
               );
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,20 +5,22 @@ import {
   useQueries,
   useQueryClient,
 } from '@tanstack/react-query';
+import { AxiosInstance } from 'axios';
 import { createCacheUtils } from './cache';
 import { combineQueries } from './combination';
 import { APIQueryHooks, RoughEndpoints } from './types';
 import { APIClient, createQueryKey } from './util';
 
-export type CreateAPIQueryHooksOptions<Endpoints extends RoughEndpoints> = {
+export type CreateAPIQueryHooksOptions = {
   name: string;
-  client: APIClient<Endpoints>;
+  client: AxiosInstance;
 };
 
 export const createAPIHooks = <Endpoints extends RoughEndpoints>({
   name,
-  client,
-}: CreateAPIQueryHooksOptions<Endpoints>): APIQueryHooks<Endpoints> => {
+  client: axiosClient,
+}: CreateAPIQueryHooksOptions): APIQueryHooks<Endpoints> => {
+  const client = new APIClient<Endpoints>(axiosClient);
   return {
     useQuery: (route, payload, options) => {
       const queryKey: QueryKey = [createQueryKey(name, route, payload)];


### PR DESCRIPTION
**Note**: This PR depends on #10.

## Motivation
I wrote the docs to specify providing an `AxiosInstance` as the client instead of an `APIClient`, but forgot to update the source code.

Why I think that simplification is better:
- one less imported value for people creating hooks (no need to use an `APIClient` if they don't want to).
<!-- Describe _why_ this change should merge. -->