### PR TITLE
feat: expose context to handlers

### DIFF
--- a/src/hooks.test.tsx
+++ b/src/hooks.test.tsx
@@ -98,6 +98,9 @@ describe('useAPIQuery', () => {
             'test-header': 'test-value',
           }),
         }),
+        expect.objectContaining({
+          delay: expect.any(Function),
+        }),
       );
     });
   });
@@ -131,6 +134,9 @@ describe('useAPIMutation', () => {
       expect(networkPost).toHaveBeenCalledWith(
         expect.objectContaining({
           body: { message: 'something' },
+        }),
+        expect.objectContaining({
+          delay: expect.any(Function),
         }),
       );
     });
@@ -291,6 +297,9 @@ describe('useCombinedAPIQueries', () => {
           headers: expect.objectContaining({
             'test-header': 'test-value',
           }),
+        }),
+        expect.objectContaining({
+          delay: expect.any(Function),
         }),
       );
     });

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -41,10 +41,13 @@ describe('createAPIMockingUtility', () => {
     });
 
     test('GET success with function responses', async () => {
-      network.mock('GET /items/:id', (req) => ({
-        status: 200,
-        data: { message: `${req.query.filter}|${req.params.id}` },
-      }));
+      network.mock('GET /items/:id', (req, ctx) => {
+        ctx.delay(50);
+        return {
+          status: 200,
+          data: { message: `${req.query.filter}|${req.params.id}` },
+        };
+      });
 
       const payload = { id: v4(), filter: v4() };
       const result = await client.request('GET /items/:id', payload);

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -19,6 +19,7 @@ type MockRequestHandler<
   & (Route extends (`GET ${string}` | `DELETE ${string}`)
     ? { query: Endpoints[Route]['Request'] }
     : { body: Endpoints[Route]['Request'] }),
+  context: msw.RestContext,
 ) =>
   | APIMockerResponse<Endpoints[Route]['Response']>
   | Promise<APIMockerResponse<Endpoints[Route]['Response']>>;
@@ -118,20 +119,26 @@ export const createAPIMocker = <Endpoints extends RoughEndpoints>(
             for (const [key, value] of req.url.searchParams.entries()) {
               query[key] = value;
             }
-            // @ts-expect-error TypeScript isn't smart enough to narrow down
-            // the GET/DELETE case here.
-            mockedResponse = await handlerOrResponse({
-              ...mockRequest,
-              query,
-            });
+            mockedResponse = await handlerOrResponse(
+              // @ts-expect-error TypeScript isn't smart enough to narrow down
+              // the GET/DELETE case here.
+              {
+                ...mockRequest,
+                query,
+              },
+              ctx,
+            );
           } else {
             const body = await req.json();
-            // @ts-expect-error TypeScript isn't smart enough to narrow down
-            // the GET/DELETE case here.
-            mockedResponse = await handlerOrResponse({
-              ...mockRequest,
-              body,
-            });
+            mockedResponse = await handlerOrResponse(
+              // @ts-expect-error TypeScript isn't smart enough to narrow down
+              // the GET/DELETE case here.
+              {
+                ...mockRequest,
+                body,
+              },
+              ctx,
+            );
           }
 
           return resolve(


### PR DESCRIPTION
## Motivation

Exposing the context could come in handy to allow users to have a bit more control that they would if they were using msw directly and it will expose some helper functions like `delay` 