### PR TITLE
feat!: ship ESM

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["./**/*.ts", "./**/*.tsx"],
   "compilerOptions": {
     "lib": ["es2020", "DOM"],
-    "module": "commonjs",
+    "module": "ES2022",
     "outDir": "./dist",
     "jsx": "react",
     "esModuleInterop": false,


### PR DESCRIPTION
## Motivation
`react-query` ships two "copies" of itself in its NPM package: one that is CJS, and one that is ESM.

This can be a footgun in our "peer dependency" situation -- see this GitHub issue for a perfect description of what can happen: https://github.com/TanStack/query/issues/4966.

Since most internal LifeOmic UI applications are running on ESM, the easiest fix here was to just update `one-query` to ship ESM output.