### PR TITLE
feat: add use api infinite query hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,36 +208,53 @@ query.data; // Message[]
 
 Queries are cached using a combination of `route name + payload`. So, in the example above, the query key looks roughly like `['GET /messages', { filter: 'some-filter' }]`.
 
-### `useAPIInfiniteQuery`
+### `useInfiniteAPIQuery`
 
 Type-safe wrapper around `useInfiniteQuery` from `react-query` which has a similar api as `useQuery` with a few key differences.
 
-```typescript
-const query = useAPIInfiniteQuery(
+```tsx
+const query = useInfiniteAPIQuery(
   'GET /list',
   {
-    // specify the property name on the payload that would indicate the next page
-    nextPageParamKey: 'after',
-    // on subsequent requests on the same list 'after' will be populated by the
-    // returned value from `getNextPageParam`
     after: undefined,
   },
   {
-    // from the previous response populate the `after` value that will be used on
-    // the payload for the next request
-    getNextPageParam: (last) => {
-      return (last as { next?: string }).next;
-    },
+    getNextPageParam: (lastPage) => ({ after: lastPage.next }),
+    getPreviousPageParam: (firstPage) => ({ before: firstPage.previous }),
   },
 );
+
+...
+
+<button
+  onClick={() => {
+    void query.fetchNextPage();
+
+    // Or fetch previous page
+    // void query.fetchPreviousPage();
+  }}
+/>;
 ```
 
 The return value of this hook is identical to the behavior of the `react-query` `useInfiniteQuery` hook's return value where `data` holds an array of pages.
+
+When returning `undefined` from `getNextPageParam` it will set `query.hasNextPage` to false, otherwise it will merge the next api request payload with the returned object, likewise for `getPreviousPageParam` and `query.hasPreviousPage`.
 
 ```tsx
 {
   query.data.pages.flatMap((page) => page.items.map((item) => ...));
 }
+```
+
+An alternative to using the `getNextPageParam` or `getPreviousPageParam` callback options, the query methods also accept a `pageParam` input.
+
+```typescript
+const lastPage = query?.data?.pages[query.data.pages.length - 1];
+query.fetchNextPage({
+  pageParam: {
+    after: lastPage?.next,
+  },
+});
 ```
 
 ### `useAPIMutation`

--- a/README.md
+++ b/README.md
@@ -208,6 +208,38 @@ query.data; // Message[]
 
 Queries are cached using a combination of `route name + payload`. So, in the example above, the query key looks roughly like `['GET /messages', { filter: 'some-filter' }]`.
 
+### `useAPIInfiniteQuery`
+
+Type-safe wrapper around `useInfiniteQuery` from `react-query` which has a similar api as `useQuery` with a few key differences.
+
+```typescript
+const query = useAPIInfiniteQuery(
+  'GET /list',
+  {
+    // specify the property name on the payload that would indicate the next page
+    nextPageParamKey: 'after',
+    // on subsequent requests on the same list 'after' will be populated by the
+    // returned value from `getNextPageParam`
+    after: undefined,
+  },
+  {
+    // from the previous response populate the `after` value that will be used on
+    // the payload for the next request
+    getNextPageParam: (last) => {
+      return (last as { next?: string }).next;
+    },
+  },
+);
+```
+
+The return value of this hook is identical to the behavior of the `react-query` `useInfiniteQuery` hook's return value where `data` holds an array of pages.
+
+```tsx
+{
+  query.data.pages.flatMap((page) => page.items.map((item) => ...));
+}
+```
+
 ### `useAPIMutation`
 
 Type-safe wrapper around `useMutation` from `react-query`.

--- a/src/hooks.test.tsx
+++ b/src/hooks.test.tsx
@@ -178,7 +178,6 @@ describe('useInfiniteAPIQuery', () => {
         after: undefined,
       });
 
-      query.hasPreviousPage;
       return (
         <div>
           <button
@@ -260,12 +259,6 @@ describe('useInfiniteAPIQuery', () => {
       2,
       expect.objectContaining({
         query: { filter: 'some-filter', after: next },
-      }),
-    );
-    expect(listSpy).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        query: { filter: 'some-filter' },
       }),
     );
     expect(listSpy).toHaveBeenNthCalledWith(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,6 @@
 import {
   useQuery,
+  useInfiniteQuery,
   useMutation,
   QueryKey,
   useQueries,
@@ -30,6 +31,30 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
           client
             .request(route, payload, options?.axios)
             .then((res) => res.data),
+        options,
+      );
+    },
+    useAPIInfiniteQuery: (route, initPayload, options) => {
+      const { nextPageParamKey } = initPayload;
+      // @ts-expect-error, typescript enforcing only deleting non-required props
+      delete initPayload.nextPageParamKey;
+      const queryKey: QueryKey = [createQueryKey(name, route, initPayload)];
+      return useInfiniteQuery(
+        queryKey,
+        ({ pageParam }) => {
+          const nextPayload =
+            pageParam && nextPageParamKey
+              ? {
+                  ...initPayload,
+                  [nextPageParamKey]: pageParam,
+                }
+              : undefined;
+          const payload = nextPayload || initPayload;
+
+          return client
+            .request(route, payload, options?.axios)
+            .then((res) => res.data);
+        },
         options,
       );
     },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -34,22 +34,15 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
         options,
       );
     },
-    useAPIInfiniteQuery: (route, initPayload, options) => {
-      const { nextPageParamKey } = initPayload;
-      // @ts-expect-error, typescript enforcing only deleting non-required props
-      delete initPayload.nextPageParamKey;
+    useInfiniteAPIQuery: (route, initPayload, options) => {
       const queryKey: QueryKey = [createQueryKey(name, route, initPayload)];
-      return useInfiniteQuery(
+      const query = useInfiniteQuery(
         queryKey,
         ({ pageParam }) => {
-          const nextPayload =
-            pageParam && nextPageParamKey
-              ? {
-                  ...initPayload,
-                  [nextPageParamKey]: pageParam,
-                }
-              : undefined;
-          const payload = nextPayload || initPayload;
+          const payload = {
+            ...initPayload,
+            ...pageParam,
+          } as typeof initPayload;
 
           return client
             .request(route, payload, options?.axios)
@@ -57,6 +50,8 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
         },
         options,
       );
+
+      return query;
     },
     useAPIMutation: (route, options) =>
       useMutation(

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ import {
   UseMutationResult,
   UseQueryOptions,
   UseQueryResult,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryResult,
 } from '@tanstack/react-query';
 import { AxiosRequestConfig } from 'axios';
 import { CombinedQueriesResult } from './combination';
@@ -46,10 +48,14 @@ export type RequestPayloadOf<
   Route extends keyof Endpoints,
 > = Endpoints[Route]['Request'] & PathParamsOf<Route>;
 
-type RestrictedUseQueryOptions<Response> = Omit<
-  UseQueryOptions<Response, unknown>,
-  'queryKey' | 'queryFn'
-> & {
+type QueryOptions<Response> =
+  | UseQueryOptions<Response, unknown>
+  | UseInfiniteQueryOptions<Response, unknown>;
+
+type RestrictedUseQueryOptions<
+  Response,
+  TQueryOptions extends QueryOptions<Response> = UseQueryOptions<Response>,
+> = Omit<TQueryOptions, 'queryKey' | 'queryFn'> & {
   axios?: AxiosRequestConfig;
 };
 
@@ -100,6 +106,17 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
     payload: RequestPayloadOf<Endpoints, Route>,
     options?: RestrictedUseQueryOptions<Endpoints[Route]['Response']>,
   ) => UseQueryResult<Endpoints[Route]['Response']>;
+
+  useAPIInfiniteQuery: <Route extends keyof Endpoints & string>(
+    route: Route,
+    payload: RequestPayloadOf<Endpoints, Route> & {
+      nextPageParamKey: keyof RequestPayloadOf<Endpoints, Route>;
+    },
+    options?: RestrictedUseQueryOptions<
+      Endpoints[Route]['Response'],
+      UseInfiniteQueryOptions
+    >,
+  ) => UseInfiniteQueryResult<Endpoints[Route]['Response']>;
 
   useAPIMutation: <Route extends keyof Endpoints & string>(
     route: Route,


### PR DESCRIPTION
## Motivation

Recently I had my first experience doing pagination with `react-query` and it didn't work how I initially expected where I thought it would be more like `apollo`

it seems that for paging through an infinite scroll they suggest using the `useInfiniteQuery` hook which we didn't have access too through `one-query` - this PR adds support 

