### PR TITLE
feat: support updating cache of a infinite query entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,12 +455,12 @@ cache.updateCache(
 );
 ```
 
-When dealing with a cache entry that is paginated prefer using `updatePaginatedCache` which behaves the same as `updateCache`
+When dealing with a cache entry that was initiated via `useInfiniteAPIQuery` (paginated) prefer using `updateInfiniteCache` which otherwise behaves the same as `updateCache`
 
 ```typescript
 const cache = useAPICache();
 
-cache.updatePaginatedCache(
+cache.updateInfiniteCache(
   'GET /list',
   { filter: 'some-filter' },
   (current) => {...},

--- a/README.md
+++ b/README.md
@@ -455,6 +455,18 @@ cache.updateCache(
 );
 ```
 
+When dealing with a cache entry that is paginated prefer using `updatePaginatedCache` which behaves the same as `updateCache`
+
+```typescript
+const cache = useAPICache();
+
+cache.updatePaginatedCache(
+  'GET /list',
+  { filter: 'some-filter' },
+  (current) => {...},
+);
+```
+
 **Note**: if performing a programmatic update, _no update will occur_ if there is not a cached value.
 
 ## Test Utility API Reference

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -43,7 +43,7 @@ const createQueryFilterFromSpec = <Endpoints extends RoughEndpoints>(
     }),
 });
 
-export const infinite = 'infinite' as const;
+export const INFINITE_QUERY_KEY = 'infinite' as const;
 
 export const createCacheUtils = <Endpoints extends RoughEndpoints>(
   client: QueryClient,
@@ -53,7 +53,7 @@ export const createCacheUtils = <Endpoints extends RoughEndpoints>(
   ) => InternalQueryKey,
 ): CacheUtils<Endpoints> => {
   const updateCache: (
-    keyPrefix?: typeof infinite,
+    keyPrefix?: typeof INFINITE_QUERY_KEY,
   ) => CacheUtils<Endpoints>['updateCache'] =
     (keyPrefix) => (route, payload, updater) => {
       client.setQueryData<Endpoints[typeof route]['Response']>(
@@ -82,6 +82,6 @@ export const createCacheUtils = <Endpoints extends RoughEndpoints>(
       void client.resetQueries(createQueryFilterFromSpec(spec));
     },
     updateCache: updateCache(),
-    updateInfiniteCache: updateCache(infinite),
+    updateInfiniteCache: updateCache(INFINITE_QUERY_KEY),
   };
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { AxiosInstance } from 'axios';
-import { createCacheUtils } from './cache';
+import { createCacheUtils, infinite } from './cache';
 import { combineQueries } from './combination';
 import { APIQueryHooks, RoughEndpoints } from './types';
 import { APIClient, createQueryKey } from './util';
@@ -35,7 +35,10 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
       );
     },
     useInfiniteAPIQuery: (route, initPayload, options) => {
-      const queryKey: QueryKey = [createQueryKey(name, route, initPayload)];
+      const queryKey: QueryKey = [
+        infinite,
+        createQueryKey(name, route, initPayload),
+      ];
       const query = useInfiniteQuery(
         queryKey,
         ({ pageParam }) => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,6 +42,8 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
           const payload = {
             ...initPayload,
             ...pageParam,
+            // casting here because `pageParam` is typed `any` and once it is
+            // merged with initPayload it makes `payload` `any`
           } as typeof initPayload;
 
           return client

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { AxiosInstance } from 'axios';
-import { createCacheUtils, infinite } from './cache';
+import { createCacheUtils, INFINITE_QUERY_KEY } from './cache';
 import { combineQueries } from './combination';
 import { APIQueryHooks, RoughEndpoints } from './types';
 import { APIClient, createQueryKey } from './util';
@@ -36,7 +36,7 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
     },
     useInfiniteAPIQuery: (route, initPayload, options) => {
       const queryKey: QueryKey = [
-        infinite,
+        INFINITE_QUERY_KEY,
         createQueryKey(name, route, initPayload),
       ];
       const query = useInfiniteQuery(

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,7 @@ export type CacheUtils<Endpoints extends RoughEndpoints> = {
     updater: CacheUpdate<Endpoints[Route]['Response']>,
   ) => void;
 
-  updatePaginatedCache: <Route extends keyof Endpoints & string>(
+  updateInfiniteCache: <Route extends keyof Endpoints & string>(
     route: Route,
     payload: RequestPayloadOf<Endpoints, Route>,
     updater: CacheUpdate<InfiniteData<Endpoints[Route]['Response']>>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import {
   UseInfiniteQueryResult,
   FetchNextPageOptions,
   FetchPreviousPageOptions,
+  InfiniteData,
   InfiniteQueryObserverResult,
 } from '@tanstack/react-query';
 import { AxiosRequestConfig } from 'axios';
@@ -121,6 +122,12 @@ export type CacheUtils<Endpoints extends RoughEndpoints> = {
     route: Route,
     payload: RequestPayloadOf<Endpoints, Route>,
     updater: CacheUpdate<Endpoints[Route]['Response']>,
+  ) => void;
+
+  updatePaginatedCache: <Route extends keyof Endpoints & string>(
+    route: Route,
+    payload: RequestPayloadOf<Endpoints, Route>,
+    updater: CacheUpdate<InfiniteData<Endpoints[Route]['Response']>>,
   ) => void;
 };
 


### PR DESCRIPTION
Tad better to review [without whitespace](https://github.com/lifeomic/one-query/pull/25/files?diff=split&w=1)

## Motivation

I didn't consider earlier how the cache updater utility behaved with `useInfiniteAPIQuery` but currently `cache.updateCache` won't type the value correctly where it needs to be wrapped in `InfiniteData`.

This pr adds a new cache utility `updatePaginatedCache`

```typescript
cache.updatePaginatedCache(
  'GET /list',
  {
    filter: 'some-filter',
  },
  (data) => {

    // data is now typed correctly

    data.pages.at(-1).items.push({
      message: 'cache-message',
    });
  },
);
```

I don't love the approach because while the implementation is exactly the same as `updateCache` we have to have a new method just for the correct types. but I thought it might make the most sense out of a few alternatives 

## Other considerations

- add a generic param to `cache.updateCache` and use that to conditionally return a different type
  - one issue here is that we would then have to also specify the route generic param anytime using the non defaults `cache.updateCache<'GET /list', 'paginated'>(...)`
- Switch based on some property on `Endpoints`
  - This doesn't fit super well where we generate the endpoints based on schema introspection unless we want to add first class support for in `one-schema`. if we did do this we could probably infer which request params are used for `nextPageToken`

Would love to hear what others think, there might be a better way to improve one of my ideas or a better idea all together