### PR TITLE
feat: allow specifying a client using a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ export const {
 } = hooks;
 ```
 
+If you'd like to define your Axios client in some other way (e.g. using React Context and/or hooks), you can specify a _function_ for getting the client. It is safe to use React hooks within this function -- it will be called according to the rules of hooks:
+
+```typescript
+const hooks = createAPIHooks<APIEndpoints>({
+  name: 'my-api',
+  client: () => {
+    return useMyClient();
+  },
+});
+```
+
 ### `useAPIQuery`
 
 Type-safe wrapper around `useQuery` from `react-query`.


### PR DESCRIPTION
## Motivation
I've encountered multiple scenarios where it'd be ideal to be able to specify an Axios client to `one-query` _outside_ of import-time.

This PR adds a simple feature: ability to provide a hooks-compatible function for returning a client. This is now possible:

```typescript
import { createAPIHooks } from '@lifeomic/one-query';

const hooks = createAPIHooks({
  name: '...',
  // Previously, this Axios client had to be specified statically.
  // Now, we can use a function, and can even use hooks within that function.
  client: () => {
    return useMyAxiosClient();
  }
})
```

While I tend to personally _prefer_ defining the client statically (b/c in my opinion it leads to more explicit code), I think this option will undoubtedly make the package more approachable, esp. for existing projects that may use such a pattern to expose their clients. In the immediate term, this will allow for smoother adoption in `react-native-sdk`.

<!-- Describe _why_ this change should merge. -->