### PR TITLE
feat: support arbitrary axios parameters in useAPIMutation

### DIFF
--- a/src/hooks.test.tsx
+++ b/src/hooks.test.tsx
@@ -363,6 +363,47 @@ describe('useAPIMutation', () => {
       );
     });
   });
+
+  test('axios parameters works', async () => {
+    const networkPost = jest.fn().mockReturnValue({
+      status: 200,
+      data: { message: 'another-test-message' },
+    });
+    network.mock('POST /items', networkPost);
+
+    const screen = render(() => {
+      const mutation = useAPIMutation('POST /items', {
+        axios: {
+          headers: {
+            'test-header': 'test-value',
+          },
+        },
+      });
+      return (
+        <button
+          onClick={() => {
+            mutation.mutate({ message: 'something' });
+          }}
+        >
+          Press Me
+        </button>
+      );
+    });
+
+    TestingLibrary.fireEvent.click(screen.getByText('Press Me'));
+
+    await TestingLibrary.waitFor(() => {
+      expect(networkPost).toHaveBeenCalledTimes(1);
+      expect(networkPost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: { message: 'something' },
+          headers: expect.objectContaining({
+            'test-header': 'test-value',
+          }),
+        }),
+      );
+    });
+  });
 });
 
 describe('useCombinedAPIQueries', () => {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -74,7 +74,10 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
       const client = useClient();
 
       return useMutation(
-        (payload) => client.request(route, payload).then((res) => res.data),
+        (payload) =>
+          client
+            .request(route, payload, options?.axios)
+            .then((res) => res.data),
         options,
       );
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -192,7 +192,9 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
       Endpoints[Route]['Response'],
       unknown,
       RequestPayloadOf<Endpoints, Route>
-    >,
+    > & {
+      axios?: AxiosRequestConfig;
+    },
   ) => UseMutationResult<
     Endpoints[Route]['Response'],
     unknown,


### PR DESCRIPTION
## Motivation
Today, `useAPIMutation` does not provide any way to override/customize the `AxiosRequestConfig`. This is a good start.
<!-- Describe _why_ this change should merge. -->