### PR TITLE
feat: add suspense query hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,18 +243,19 @@ if (query.isError) {
 query.data; // Message[]
 ```
 
-### `useInfiniteAPIQuery`
+### `useSuspenseInfiniteAPIQuery`
 
-Type-safe wrapper around [`useInfiniteQuery`](https://tanstack.com/query/latest/docs/react/reference/useInfiniteQuery) from `react-query` which has a similar api as `useQuery` with a few key differences.
+Type-safe wrapper around [`useSuspenseInfiniteQuery`](https://tanstack.com/query/latest/docs/react/reference/useSuspenseInfiniteQuery) from `react-query`
 
 ```tsx
-const query = useInfiniteAPIQuery(
+const query = useSuspenseInfiniteAPIQuery(
   'GET /list',
   {
     // after is the token name in query string for the next page to return.
     after: undefined,
   },
   {
+    initialPageParam: {},
     // passes the pagination token from request body to query string "after"
     getNextPageParam: (lastPage) => ({ after: lastPage.next }),
     getPreviousPageParam: (firstPage) => ({ before: firstPage.previous }),
@@ -284,15 +285,46 @@ is required over query string. It may need another queryFn if the pagination tok
 }
 ```
 
-An alternative to using the `getNextPageParam` or `getPreviousPageParam` callback options, the query methods also accept a `pageParam` input.
+### `useInfiniteAPIQuery`
 
-```typescript
-const lastPage = query?.data?.pages[query.data.pages.length - 1];
-query.fetchNextPage({
-  pageParam: {
-    after: lastPage?.next,
+Type-safe wrapper around [`useInfiniteQuery`](https://tanstack.com/query/latest/docs/react/reference/useInfiniteQuery) from `react-query` which has a similar api as `useQuery` with a few key differences.
+
+```tsx
+const query = useInfiniteAPIQuery(
+  'GET /list',
+  {
+    // after is the token name in query string for the next page to return.
+    after: undefined,
   },
-});
+  {
+    initialPageParam: {},
+    // passes the pagination token from request body to query string "after"
+    getNextPageParam: (lastPage) => ({ after: lastPage.next }),
+    getPreviousPageParam: (firstPage) => ({ before: firstPage.previous }),
+  },
+);
+
+...
+
+<button
+  onClick={() => {
+    void query.fetchNextPage();
+
+    // Or fetch previous page
+    // void query.fetchPreviousPage();
+  }}
+/>;
+```
+
+The return value of this hook is identical to the behavior of the `react-query` `useInfiniteQuery` hook's return value where `data` holds an array of pages.
+
+When returning `undefined` from `getNextPageParam` it will set `query.hasNextPage` to false, otherwise it will merge the next api request payload with the returned object, likewise for `getPreviousPageParam` and `query.hasPreviousPage`. This is useful to pass pagination token from previous page since the current implementation provides a default `queryFn` assumes such token
+is required over query string. It may need another queryFn if the pagination token is managed via headers.
+
+```tsx
+{
+  query.data.pages.flatMap((page) => page.items.map((item) => ...));
+}
 ```
 
 ### `useAPIMutation`

--- a/README.md
+++ b/README.md
@@ -190,6 +190,29 @@ const hooks = createAPIHooks<APIEndpoints>({
 });
 ```
 
+### `useSuspenseAPIQuery`
+
+Type-safe wrapper around `useSuspenseQuery` from `react-query`. Be sure to use within a `<React.Suspense />` boundary.
+
+```typescript
+const query = useSuspenseAPIQuery(
+  // First, specify the route.
+  'GET /messages',
+  // Then, specify the payload.
+  { filter: 'some-filter' },
+);
+```
+
+The return value of this hook is identical to the behavior of the `react-query` `useSuspenseQuery` hook's return value.
+
+```typescript
+const query = useQuery('GET /messages', { filter: 'some-filter' });
+
+query.data; // Message[]
+```
+
+Queries are cached using a combination of `route name + payload`. So, in the example above, the query key looks roughly like `['GET /messages', { filter: 'some-filter' }]`.
+
 ### `useAPIQuery`
 
 Type-safe wrapper around `useQuery` from `react-query`.
@@ -219,8 +242,6 @@ if (query.isError) {
 
 query.data; // Message[]
 ```
-
-Queries are cached using a combination of `route name + payload`. So, in the example above, the query key looks roughly like `['GET /messages', { filter: 'some-filter' }]`.
 
 ### `useInfiniteAPIQuery`
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ const hooks = createAPIHooks<APIEndpoints>({ // <-- Specify your custom type her
 
 export const {
   useAPIQuery,
-  useAPIMutation
+  useSuspenseAPIQuery,
+  useInfiniteAPIQuery,
+  useSuspenseInfiniteAPIQuery,
+  useAPIMutation,
   useCombinedAPIQueries,
-  useAPICache
+  useSuspenseCombinedAPIQueries,
+  useAPICache,
 } = hooks;
 ```
 
@@ -350,9 +354,72 @@ return (
 );
 ```
 
-### `useCombinedAPIQueries`
+### `useSuspenseCombinedAPIQueries`
 
 A helper for combining multiple parallel queries into a single `react-query`-like hook.
+
+Queries performed using this hook are cached independently, just as if they had been performed individually using `useSuspenseAPIQuery`.
+
+```typescript
+const query = useSuspenseCombinedAPIQueries(
+  ['GET /messages', { filter: 'some-filter' }],
+  ['GET /messages/:id', { id: 'some-message-id' }],
+);
+
+// Here all queries are complete - pending and error states are handled by suspense and error boundaries
+
+query.data; // [Message[], Message]
+
+const [list, message] = query.data;
+
+list; // Message[]
+message; // Message
+```
+
+#### `isFetching`
+
+Indicates whether _at least one_ query is in the "fetching" state.
+
+#### `isRefetching`
+
+Indicates whether _at least one_ query is in the "refetching" state.
+
+#### `refetchAll()`
+
+A helper function for triggering a refetch of every independent query in the combination.
+
+```typescript
+const query = useSuspenseCombinedAPIQueries(
+  ['GET /messages', { filter: 'some-filter' }],
+  ['GET /messages/:id', { id: 'some-message-id' }],
+);
+
+// This:
+query.refetchAll();
+
+// Is equivalent to:
+for (const individualQuery of query.queries) {
+  void individualQuery.refetch();
+}
+```
+
+#### `queries`
+
+Provides access to the individual underlying queries.
+
+```typescript
+const query = useSuspenseCombinedAPIQueries(
+  ['GET /messages', { filter: 'some-filter' }],
+  ['GET /messages/:id', { id: 'some-message-id' }],
+);
+
+query.queries[0].data; // Messages[]
+query.queries[1].data; // Message
+```
+
+### `useCombinedAPIQueries`
+
+A helper for combining multiple parallel queries into a single `react-query`-like hook. A non-suspense version of `useSuspenseCombinedAPIQueries`.
 
 Queries performed using this hook are cached independently, just as if they had been performed individually using `useAPIQuery`.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.12",
     "semantic-release": "^19.0.5",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.4",

--- a/src/combination.ts
+++ b/src/combination.ts
@@ -139,6 +139,9 @@ export const suspenseCombineQueries = <Queries extends QueryObserverResult[]>(
     isPending: false,
     data: queries.map((query) => query.data) as any,
     isError: false,
+    // Data is typed as unknown[] because it can't infer it
+    // correctly - here we cast it as any, in types we give
+    // it the correct type we expect.
     queries: queries as any,
   };
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,6 +4,7 @@ import {
   useMutation,
   QueryKey,
   useQueryClient,
+  useSuspenseQuery,
   useQueries,
   QueriesOptions,
 } from '@tanstack/react-query';
@@ -45,6 +46,22 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
           client
             .request(route, payload, options?.axios)
             .then((res) => res.data),
+      });
+
+      return query;
+    },
+
+    useSuspenseAPIQuery: (route, payload, options) => {
+      const client = useClient();
+      const queryKey: QueryKey = [createQueryKey(name, route, payload)];
+
+      const query = useSuspenseQuery({
+        queryKey,
+        queryFn: () =>
+          client
+            .request(route, payload, options?.axios)
+            .then((res) => res.data),
+        ...options,
       });
 
       return query;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,6 +7,7 @@ import {
   useSuspenseQuery,
   useQueries,
   QueriesOptions,
+  useSuspenseInfiniteQuery,
 } from '@tanstack/react-query';
 import { AxiosInstance } from 'axios';
 import { createCacheUtils, INFINITE_QUERY_KEY } from './cache';
@@ -94,6 +95,35 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
 
       return query;
     },
+
+    useSuspenseInfiniteAPIQuery: (route, initPayload, options) => {
+      const client = useClient();
+      const queryKey: QueryKey = [
+        INFINITE_QUERY_KEY,
+        createQueryKey(name, route, initPayload),
+      ];
+
+      const query = useSuspenseInfiniteQuery({
+        ...options,
+        queryKey,
+        initialPageParam: options.initialPageParam,
+        queryFn: ({ pageParam }) => {
+          const payload = {
+            ...initPayload,
+            ...(pageParam as any),
+            // casting here because `pageParam` is typed `any` and once it is
+            // merged with initPayload it makes `payload` `any`
+          } as typeof initPayload;
+
+          return client
+            .request(route, payload, options?.axios)
+            .then((res) => res.data) as any;
+        },
+      });
+
+      return query;
+    },
+
     useAPIMutation: (route, options) => {
       const client = useClient();
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -80,7 +80,6 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
       const query = useInfiniteQuery({
         ...options,
         queryKey,
-        initialPageParam: options.initialPageParam,
         queryFn: ({ pageParam }) => {
           const payload = {
             ...initPayload,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import {
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
   InfiniteData,
+  UseSuspenseQueryResult,
+  UseSuspenseQueryOptions,
   DefaultError,
 } from '@tanstack/react-query';
 import { AxiosRequestConfig } from 'axios';
@@ -55,6 +57,17 @@ type RestrictedUseQueryOptions<
   TError = DefaultError,
   Data = Response,
 > = Omit<UseQueryOptions<Response, TError, Data>, 'queryKey' | 'queryFn'> & {
+  axios?: AxiosRequestConfig;
+};
+
+type RestrictedUseSuspenseQueryOptions<
+  Response,
+  TError = DefaultError,
+  Data = Response,
+> = Omit<
+  UseSuspenseQueryOptions<Response, TError, Data>,
+  'queryKey' | 'queryFn'
+> & {
   axios?: AxiosRequestConfig;
 };
 
@@ -156,6 +169,19 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
       Data
     >,
   ) => UseQueryResult<Data>;
+
+  useSuspenseAPIQuery: <
+    Route extends keyof Endpoints & string,
+    Data = Endpoints[Route]['Response'],
+  >(
+    route: Route,
+    payload: RequestPayloadOf<Endpoints, Route>,
+    options?: RestrictedUseSuspenseQueryOptions<
+      Endpoints[Route]['Response'],
+      DefaultError,
+      Data
+    >,
+  ) => UseSuspenseQueryResult<Data>;
 
   useInfiniteAPIQuery: <Route extends keyof Endpoints & string>(
     route: Route,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ import {
   InfiniteData,
   UseSuspenseQueryResult,
   UseSuspenseQueryOptions,
+  UseSuspenseInfiniteQueryOptions,
+  UseSuspenseInfiniteQueryResult,
   DefaultError,
 } from '@tanstack/react-query';
 import { AxiosRequestConfig } from 'axios';
@@ -73,6 +75,20 @@ type RestrictedUseSuspenseQueryOptions<
 
 type RestrictedUseInfiniteQueryOptions<Response, Request> = Omit<
   UseInfiniteQueryOptions<InfiniteData<Response>, DefaultError>,
+  | 'queryKey'
+  | 'queryFn'
+  | 'initialPageParam'
+  | 'getNextPageParam'
+  | 'getPreviousPageParam'
+> & {
+  axios?: AxiosRequestConfig;
+  initialPageParam: Partial<Request>; // use init payload?
+  getNextPageParam: (lastPage: Response) => Partial<Request> | undefined;
+  getPreviousPageParam?: (firstPage: Response) => Partial<Request> | undefined;
+};
+
+type RestrictedUseSuspenseInfiniteQueryOptions<Response, Request> = Omit<
+  UseSuspenseInfiniteQueryOptions<InfiniteData<Response>, DefaultError>,
   | 'queryKey'
   | 'queryFn'
   | 'initialPageParam'
@@ -191,6 +207,18 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
       RequestPayloadOf<Endpoints, Route>
     >,
   ) => UseInfiniteQueryResult<
+    InfiniteData<Endpoints[Route]['Response']>,
+    DefaultError
+  >;
+
+  useSuspenseInfiniteAPIQuery: <Route extends keyof Endpoints & string>(
+    route: Route,
+    payload: RequestPayloadOf<Endpoints, Route>,
+    options: RestrictedUseSuspenseInfiniteQueryOptions<
+      Endpoints[Route]['Response'],
+      RequestPayloadOf<Endpoints, Route>
+    >,
+  ) => UseSuspenseInfiniteQueryResult<
     InfiniteData<Endpoints[Route]['Response']>,
     DefaultError
   >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,10 @@ import {
   DefaultError,
 } from '@tanstack/react-query';
 import { AxiosRequestConfig } from 'axios';
-import { CombinedQueriesResult } from './combination';
+import {
+  CombinedQueriesResult,
+  SuspenseCombinedQueriesResult,
+} from './combination';
 
 /**
  * Extracts the path parameters from a route.
@@ -241,6 +244,14 @@ export type APIQueryHooks<Endpoints extends RoughEndpoints> = {
   useCombinedAPIQueries<Routes extends (keyof Endpoints & string)[]>(
     ...routes: [...CombinedRouteTuples<Endpoints, Routes>]
   ): CombinedQueriesResult<{
+    [Index in keyof Routes]: QueryObserverResult<
+      Endpoints[Routes[Index]]['Response']
+    >;
+  }>;
+
+  useSuspenseCombinedAPIQueries<Routes extends (keyof Endpoints & string)[]>(
+    ...routes: [...CombinedRouteTuples<Endpoints, Routes>]
+  ): SuspenseCombinedQueriesResult<{
     [Index in keyof Routes]: QueryObserverResult<
       Endpoints[Routes[Index]]['Response']
     >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ type RestrictedUseInfiniteQueryOptions<Response, Request> = Omit<
   | 'getPreviousPageParam'
 > & {
   axios?: AxiosRequestConfig;
-  initialPageParam: Partial<Request>; // use init payload?
+  initialPageParam: Partial<Request>;
   getNextPageParam: (lastPage: Response) => Partial<Request> | undefined;
   getPreviousPageParam?: (firstPage: Response) => Partial<Request> | undefined;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,6 +5605,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.12.tgz#59f8f1dbc53bbbb34fc384c8db7cf4082cb63e2c"
+  integrity sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
## Motivation

Review this pr one by one

- ~[upgrade react-query](https://github.com/lifeomic/one-query/pull/43/commits/c5a751233abfe7fe5f2f599c4fab3d8fd7e198dd), upgrade react-query package, align with latest version of react-query for supported api, setup migration guide~ Separated out into https://github.com/lifeomic/one-query/pull/44

- [First](https://github.com/lifeomic/one-query/pull/43/commits/f331441cf29880586c0a22894b577df1641bd8d4)  add `useSuspenseAPIQuery` hook
- [Second](https://github.com/lifeomic/one-query/pull/43/commits/dc809989d00a408e2ff766934828af559c011efd) add `useSuspenseInfiniteAPIQuery` hook
- [Third](https://github.com/lifeomic/one-query/pull/43/commits/38776801457e1be04f870d76aa7b7dd4859724e8) add `useSuspenseCombinedAPIQueries` hook
