### PR TITLE
feat: allow updating cache entries using a predicate function

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -181,9 +181,7 @@ export const createAPIHooks = <Endpoints extends RoughEndpoints>({
 
     useAPICache: () => {
       const client = useQueryClient();
-      return createCacheUtils(client, (route, payload) =>
-        createQueryKey(name, route, payload),
-      );
+      return createCacheUtils(client, name);
     },
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,13 +140,17 @@ export type CacheUtils<Endpoints extends RoughEndpoints> = {
 
   updateCache: <Route extends keyof Endpoints & string>(
     route: Route,
-    payload: RequestPayloadOf<Endpoints, Route>,
+    payloadOrPredicate:
+      | RequestPayloadOf<Endpoints, Route>
+      | ((payload: RequestPayloadOf<Endpoints, Route>) => boolean),
     updater: CacheUpdate<Endpoints[Route]['Response']>,
   ) => void;
 
   updateInfiniteCache: <Route extends keyof Endpoints & string>(
     route: Route,
-    payload: RequestPayloadOf<Endpoints, Route>,
+    payloadOrPredicate:
+      | RequestPayloadOf<Endpoints, Route>
+      | ((payload: RequestPayloadOf<Endpoints, Route>) => boolean),
     updater: CacheUpdate<InfiniteData<Endpoints[Route]['Response']>>,
   ) => void;
 


### PR DESCRIPTION
## Motivation
I'd like to be able to provide a _predicate_ for updating cache entries, to allow updating all cache entries for an endpoint that match a particular pattern.
<!-- Describe _why_ this change should merge. -->